### PR TITLE
"Am I right?" => Yes => skip refining knowledge

### DIFF
--- a/src/iolStateMachineHandler/app/conf/config_CAFFE.ini
+++ b/src/iolStateMachineHandler/app/conf/config_CAFFE.ini
@@ -10,5 +10,6 @@ classification_threshold    -1000.0
 improve_train_period        1.5
 train_flipped_images        off
 train_burst_images          on
+skip_learning_upon_success  on
 hist_filter_length          10
 

--- a/src/iolStateMachineHandler/include/module.h
+++ b/src/iolStateMachineHandler/include/module.h
@@ -89,7 +89,8 @@ protected:
     bool skipGazeHoming;
     bool doAttention;
     bool trainOnFlipped;
-    bool trainBurst;    
+    bool trainBurst;
+    bool skipLearningUponSuccess;
     double improve_train_period;
     double classification_threshold;
     double blockEyes;

--- a/src/iolStateMachineHandler/src/main.cpp
+++ b/src/iolStateMachineHandler/src/main.cpp
@@ -214,23 +214,26 @@ being processed or not.
 - to extend the training instance of \e T seconds within which
   collect further relevant images.
  
---train_flipped_images \e switch 
-- allow training over flipped images to improve accuracy; the 
-  value \e switch can be "on"|"off", being "off" by default.
+--train_flipped_images \e [on|off] 
+- allow training over flipped images to improve accuracy;
+  default is "off".
 
---train_burst_images \e switch 
+--train_burst_images \e [on|off] 
 - allow acquiring a burst of images over which carry out 
-  training later on; the value \e switch can be "on"|"off",
-  being "off" by default.
+  training later on; default is "off".
  
+--skip_learning_upon_success \e [on|off]
+- avoid refining the objects knowledge when the recognition is
+  successful; default is "off".
+
 --hist_filter_length \e len 
 - allow selecting the length of the moving average filter used 
   to smooth out the quickly varying scores.
  
 --block_eyes \e ver 
-- For <i>ver>0</i> specify to block eyes vergence at \e ver 
+- for <i>ver>0</i> specify to block eyes vergence at \e ver 
   angle before gazing at the object to power-grasp.
- 
+
 \section tested_os_sec Tested OS
 Windows, Linux
 

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -1207,7 +1207,7 @@ void Manager::execWhere(const string &object, const Bottle &blobs,
         else if (type==Vocab::encode("ack"))
         {
             // reinforce if an object is available
-            if ((recogBlob>=0) && (pClassifier!=NULL))
+            if (!skipLearningUponSuccess && (recogBlob>=0) && (pClassifier!=NULL))
             {
                 burst("start");
                 train(object,blobs,recogBlob);
@@ -1319,7 +1319,7 @@ void Manager::execWhat(const Bottle &blobs, const int pointedBlob,
         else if ((object!=OBJECT_UNKNOWN) && (type==Vocab::encode("ack")))
         {
             // reinforce if an object is available
-            if ((pointedBlob>=0) && (pClassifier!=NULL))
+            if (!skipLearningUponSuccess && (pointedBlob>=0) && (pClassifier!=NULL))
             {
                 burst("start");
                 train(object,blobs,pointedBlob);
@@ -2209,10 +2209,11 @@ bool Manager::configure(ResourceFinder &rf)
     improve_train_period=rf.check("improve_train_period",Value(0.0)).asDouble();
     trainOnFlipped=rf.check("train_flipped_images",Value("off")).asString()=="on";
     trainBurst=rf.check("train_burst_images",Value("off")).asString()=="on";
+    skipLearningUponSuccess=rf.check("skip_learning_upon_success",Value("off")).asString()=="on";
     classification_threshold=rf.check("classification_threshold",Value(0.5)).asDouble();
 
     histFilterLength=std::max(1,rf.check("hist_filter_length",Value(10)).asInt());
-    blockEyes=rf.check("block_eyes",Value(-1.0)).asDouble();
+    blockEyes=rf.check("block_eyes",Value(-1.0)).asDouble();    
 
     img.resize(320,240);
     imgRtLoc.resize(320,240);


### PR DESCRIPTION
Added the option `skip_learning_upon_success` to skip refining the knowledge upon successful recognition.

This is especially useful with `Caffe` coding and in a scenario where lots of objects are in the scene, since learning in this context is carried out in batch mode and training takes time.

Therefore, by default this option is "on" with `Caffe` coding.