### PR TITLE
milClassifier CMakeLists: include DL library

### DIFF
--- a/src/milClassifier/CMakeLists.txt
+++ b/src/milClassifier/CMakeLists.txt
@@ -45,7 +45,7 @@ if(boostMIL_FOUND AND SIFTGPU_FOUND)
 
     include_directories(${PROJECT_SOURCE_DIR} ${SIFTGPU_INCLUDE_DIRS})
     add_executable(${PROJECTNAME} ${folder_source} ${folder_header})
-    target_link_libraries(${PROJECTNAME} boostMIL ${OpenCV_LIBRARIES} ${YARP_LIBRARIES} ${SIFTGPU_LIBRARIES})
+    target_link_libraries(${PROJECTNAME} boostMIL ${OpenCV_LIBRARIES} ${YARP_LIBRARIES} ${SIFTGPU_LIBRARIES}  ${CMAKE_DL_LIBS})
     install(TARGETS ${PROJECTNAME} DESTINATION bin)
 
     add_subdirectory(app)


### PR DESCRIPTION
Otherwise compilation on Linux machines fails.
DL library is needed for `dlopen` in https://github.com/robotology/iol/blob/master/src/milClassifier/SiftGPU_Extractor.cpp