### PR TITLE
Added 'This is $Object' command to teach objects faster

### DIFF
--- a/app/lua/iol_funcs.lua
+++ b/app/lua/iol_funcs.lua
@@ -142,6 +142,16 @@ function IOL_what(port)
    return reply:get(0):asString()
 end
 
+function IOL_this_is(port,objName)
+   local wb = yarp.Bottle()
+   local reply = yarp.Bottle()
+   wb:clear()
+    wb:addString("this")
+    wb:addString(objName)
+    port:write(wb,reply)
+   return reply:get(0):asString()
+end
+
 function IOL_calib_kin_start(port, side, objName)
    local wb = yarp.Bottle()
    local reply = yarp.Bottle()

--- a/app/lua/iol_interact_fsm.lua
+++ b/app/lua/iol_interact_fsm.lua
@@ -12,6 +12,7 @@ event_table = {
    Forget    = "e_forget",
    Explore   = "e_explore",
    What      = "e_what",
+   This      = "e_this",
    Let       = "e_let",
    }
 
@@ -201,6 +202,14 @@ interact_fsm = rfsm.state{
            end
    },
 
+   SUB_THIS = rfsm.state{
+           entry=function()
+                   local obj = result:get(7):asString()
+
+                   local b = IOL_this_is(iol_port, obj)
+           end
+   },
+
    SUB_LET = rfsm.state{
            entry=function()
                    let_obj = result:get(17):asString()
@@ -286,6 +295,9 @@ interact_fsm = rfsm.state{
 
    rfsm.transition { src='SUB_MENU', tgt='SUB_WHAT', events={ 'e_what' } },
    rfsm.transition { src='SUB_WHAT', tgt='SUB_MENU', events={ 'e_done' } },
+
+   rfsm.transition { src='SUB_MENU', tgt='SUB_THIS', events={ 'e_this' } },
+   rfsm.transition { src='SUB_THIS', tgt='SUB_MENU', events={ 'e_done' } },
 
    rfsm.transition { src='SUB_MENU', tgt='SUB_LET', events={ 'e_let' } },
    rfsm.transition { src='SUB_LET', tgt='SUB_MENU', events={ 'e_done' } },

--- a/app/lua/iol_main.lua
+++ b/app/lua/iol_main.lua
@@ -16,7 +16,7 @@ iol_port = yarp.Port()
 object_port = yarp.Port()
 
 -- defining objects and actions vocabularies
-objects = {"Octopus", "Lego", "Toy", "Ladybug", "Turtle", "Car", "Bottle", "Box"}
+objects = {"Octopus", "Lego", "Toy", "Ladybug", "Turtle", "Car", "Bottle", "Box", "Marker", "Licence"}
 actions = {"{point at}", "{what is this}"}
 
 -- defining speech grammar for Menu

--- a/app/lua/iol_main.lua
+++ b/app/lua/iol_main.lua
@@ -16,7 +16,7 @@ iol_port = yarp.Port()
 object_port = yarp.Port()
 
 -- defining objects and actions vocabularies
-objects = {"Octopus", "Lego", "Toy", "Ladybug", "Turtle", "Car", "Bottle", "Box", "Marker", "Licence"}
+objects = {"Octopus", "Lego", "Toy", "Ladybug", "Turtle", "Car", "Bottle", "Box"}
 actions = {"{point at}", "{what is this}"}
 
 -- defining speech grammar for Menu

--- a/app/lua/iol_main.lua
+++ b/app/lua/iol_main.lua
@@ -22,7 +22,7 @@ actions = {"{point at}", "{what is this}"}
 -- defining speech grammar for Menu
 grammar = "Return to home position | Calibrate on table | Where is the #Object | Take the #Object | Grasp the #Object | See you soon  | I will teach you a new object | "
        .."Touch the #Object | Push the #Object | Let me show you how to reach the #Object with your right arm | Let me show you how to reach the #Object with your left arm | "
-        .."Forget #Object | Forget all objects | Execute a plan | What is this | Explore the #Object "
+        .."Forget #Object | Forget all objects | Execute a plan | What is this | This is a #Object | Explore the #Object "
 
 -- defining speech grammar for Reward
 grammar_reward = "Yes you are | No here it is | Skip it"

--- a/src/iolStateMachineHandler/include/module.h
+++ b/src/iolStateMachineHandler/include/module.h
@@ -155,7 +155,7 @@ protected:
     void    execForget(const string &object);
     void    execWhere(const string &object, const Bottle &blobs, const int recogBlob, Classifier *pClassifier, const string &recogType);
     void    execWhat(const Bottle &blobs, const int pointedBlob, const Bottle &scores, const string &object);
-    void    execThis(const string &object, Bottle &blobs, int &pointedBlob);
+    void    execThis(const string &object, const string &detectedObject, const Bottle &blobs, const int &pointedBlob);
     void    execExplore(const string &object);
     void    execReinforce(const string &object, const Vector &position);
     void    execInterruptableAction(const string &action, const string &object, const Bottle &blobs, const int recogBlob);

--- a/src/iolStateMachineHandler/include/module.h
+++ b/src/iolStateMachineHandler/include/module.h
@@ -155,6 +155,7 @@ protected:
     void    execForget(const string &object);
     void    execWhere(const string &object, const Bottle &blobs, const int recogBlob, Classifier *pClassifier, const string &recogType);
     void    execWhat(const Bottle &blobs, const int pointedBlob, const Bottle &scores, const string &object);
+    void    execThis(const string &object, Bottle &blobs, int &pointedBlob);
     void    execExplore(const string &object);
     void    execReinforce(const string &object, const Vector &position);
     void    execInterruptableAction(const string &action, const string &object, const Bottle &blobs, const int recogBlob);

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -1428,9 +1428,9 @@ void Manager::execThis(const string &object, const string &detectedObject, const
         ostringstream reply;
 
         //if the classifier recognized the object
-        if (object.compare(detectedObject)!=0)
-            reply<<"Oh, come on! I already know that this is a "<<object<<" is!";
-        else if(detectedObject.compare(OBJECT_UNKNOWN)!=0)
+        if (object.compare(detectedObject))
+            reply<<"Oh, come on! I already know that this is a "<<object<<"!";
+        else if(detectedObject.compare(OBJECT_UNKNOWN))
             reply<<"All right! Now I know what a "<<object<<" is";
         else
         {

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -2520,7 +2520,7 @@ bool Manager::updateModule()
         mutexMemoryUpdate.wait();
         int pointedBlob=recognize(blobs,scores,detectedObject);
 
-        execThis(activeObject,detectedObject,pointedBlob,blobs);
+        execThis(activeObject,detectedObject,blobs,pointedBlob);
         updateObjCartPosInMemory(activeObject,blobs,pointedBlob);
         mutexMemoryUpdate.post();
     }

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -1450,7 +1450,7 @@ void Manager::execThis(const string &object, const string &detectedObject, const
 
         burst("start");
         train(object,blobs,pointedBlob);
-        //improve_train(object,blobs,pointedBlob);
+        improve_train(object,blobs,pointedBlob);
         burst("stop");
  
 

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -2507,10 +2507,9 @@ bool Manager::updateModule()
     }
     else if ((rxCmd==Vocab::encode("this")) && (valHuman.size()>0))
     {
-        Bottle blobs;
-        int pointedBlob;
+        Bottle blobs,scores;
         Classifier *pClassifier;
-        
+        string detectedObject;
 
         whatGood=pointedLoc.getLoc(whatLocation);
         Time::delay(0.3);

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -1428,14 +1428,14 @@ void Manager::execThis(const string &object, const string &detectedObject, const
         ostringstream reply;
 
         //if the classifier recognized the object
-        if (object.compare(detectedObject))
-            reply<<"Oh, come on! I already know that this is a "<<object<<"!";
-        else if(detectedObject.compare(OBJECT_UNKNOWN))
-            reply<<"All right! Now I know what a "<<object<<" is";
+        if (object.compare(detectedObject)==0)
+            reply<<"Yes, I know that is a "<<object<<"!";
+        else if(detectedObject.compare(OBJECT_UNKNOWN)==0)
+            reply<<"All right! Now I know what a "<<object<<" is!";
         else
         {
-            reply<<"Oh! I though that was a "<<detectedObject<<". ";
-            reply<<"Thanks for clarifying that!";
+            reply<<"Oh dear, I thought that was a "<<detectedObject<<"?";
+       
 
             map<string,Classifier*>::iterator it_detected=db.find(detectedObject);
         
@@ -1450,7 +1450,7 @@ void Manager::execThis(const string &object, const string &detectedObject, const
 
         burst("start");
         train(object,blobs,pointedBlob);
-        improve_train(object,blobs,pointedBlob);
+        //improve_train(object,blobs,pointedBlob);
         burst("stop");
  
 

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -1409,6 +1409,7 @@ void Manager::execWhat(const Bottle &blobs, const int pointedBlob,
 /**********************************************************/
 void Manager::execThis(const string &object, Bottle &blobs, int &pointedBlob)
 {
+    Bottle replyHuman;
 
     string recogType="recognition";
     map<string,Classifier*>::iterator it=db.find(object);
@@ -2490,6 +2491,9 @@ bool Manager::updateModule()
     }
     else if ((rxCmd==Vocab::encode("this")) && (valHuman.size()>0))
     {
+        Bottle blobs;
+        int pointedBlob;
+
         whatGood=pointedLoc.getLoc(whatLocation);
         Time::delay(1.0);
 


### PR DESCRIPTION
I have added a new functionality to allow to teach objects during the demo without iterating between the human and the robot. 

Case scenario: the user points at an object and says `This is a <obj_name>`. Then the robot learns the object accordingly. Different cases are handled appropriately (e.g. Misclassification, Already known object or unknown object).

Video: https://goo.gl/photos/mG4PxCGhW8Ytoc2K9


Thanks @alecive!
