### PR TITLE
restructuring rfsm (lua) to be also used with rfsmGui

### DIFF
--- a/app/lua/iol_funcs.lua
+++ b/app/lua/iol_funcs.lua
@@ -1,4 +1,38 @@
 
+function IOL_Initialize()
+  -- initilization
+  ispeak_port = yarp.BufferedPortBottle()
+  speechRecog_port = yarp.Port()
+  iol_port = yarp.Port()
+  object_port = yarp.Port()
+
+  -- defining objects and actions vocabularies
+  objects = {"Octopus", "Lego", "Toy", "Ladybug", "Turtle", "Car", "Bottle", "Box"}
+  actions = {"{point at}", "{what is this}"}
+
+  -- defining speech grammar for Menu
+  grammar = "Return to home position | Calibrate on table | Where is the #Object | Take the #Object | Grasp the #Object | See you soon  | I will teach you a new object | "
+         .."Touch the #Object | Push the #Object | Let me show you how to reach the #Object with your right arm | Let me show you how to reach the #Object with your left arm | "
+          .."Forget #Object | Forget all objects | Execute a plan | What is this | This is a #Object | Explore the #Object "
+
+  -- defining speech grammar for Reward
+  grammar_reward = "Yes you are | No here it is | Skip it"
+
+  -- defining speech grammar for teaching a new object
+  grammar_track = "There you go | Skip it"
+
+  -- defining speech grammar for what function (ack)
+  grammar_whatAck = "Yes you are | No you are not | Skip it | Wrong this is a #Object"
+
+  -- defining speech grammar for what function (nack)
+  grammar_whatNack = "This is a #Object | Skip it"
+
+  -- defining speech grammar teach reach
+  grammar_teach = "Yes I do | No I do not | Finished"
+
+  return (ispeak_port ~= nil) and (speechRecog_port ~= nil) and (iol_port ~= nil) and (object_port ~= nil)
+end
+
 function speak(port, str)
    local wb = port:prepare()
     wb:clear()
@@ -187,9 +221,9 @@ function IH_Expand_vocab(port, objects)
         wb:addString(word)
     end
     port:write(wb,reply)
-    
+
     local rep  =  reply:get(0):asString()
-    
+
     if rep == "ack" then
         for k in pairs (objects) do
             objects[k] = nil

--- a/app/lua/iol_interact_fsm.lua
+++ b/app/lua/iol_interact_fsm.lua
@@ -47,21 +47,21 @@ return rfsm.state{
    ----------------------------------
 
    SUB_EXIT = rfsm.state{
-           entry=function()
+           doo=function()
                     speak(ispeak_port, "Ok, bye bye")
                    rfsm.send_events(fsm, 'e_menu_done')
            end
    },
 
    SUB_CALIBRATE = rfsm.state{
-           entry=function()
+           doo=function()
                    IOL_calibrate(iol_port)
                    speak(ispeak_port,"OK, I know the table height")
            end
    },
 
    SUB_WHERE = rfsm.state{
-           entry=function()
+           doo=function()
                    local obj = result:get(7):asString()
 
                    local b = IOL_where_is(iol_port, obj)
@@ -90,7 +90,7 @@ return rfsm.state{
    },
 
    SUB_TEACH_OBJ = rfsm.state{
-           entry=function()
+           doo=function()
                    IOL_track_start(iol_port)
                    local answer = SM_Reco_Grammar(speechRecog_port, grammar_track)
                    print("received REPLY: ", answer:toString() )
@@ -118,56 +118,56 @@ return rfsm.state{
    },
 
    SUB_TAKE = rfsm.state{
-           entry=function()
+           doo=function()
                    local obj = result:get(5):asString()
                    local b = IOL_take(iol_port, obj)
            end
    },
 
    SUB_GRASP = rfsm.state{
-           entry=function()
+           doo=function()
                    local obj = result:get(5):asString()
                    local b = IOL_grasp(iol_port, obj)
            end
    },
 
    SUB_RETURN = rfsm.state{
-           entry=function()
+           doo=function()
                    print("going home!")
                    IOL_goHome(iol_port)
            end
    },
 
    SUB_TOUCH = rfsm.state{
-           entry=function()
+           doo=function()
                    local obj = result:get(5):asString()
                    local b = IOL_touch(iol_port, obj)
            end
    },
 
    SUB_PUSH = rfsm.state{
-           entry=function()
+           doo=function()
                    local obj = result:get(5):asString()
                    local b = IOL_push(iol_port, obj)
            end
    },
 
    SUB_FORGET = rfsm.state{
-           entry=function()
+           doo=function()
                    local obj = result:get(3):asString()
                    local b = IOL_forget(iol_port, obj)
            end
    },
 
    SUB_EXPLORE = rfsm.state{
-           entry=function()
+           doo=function()
                    local obj = result:get(5):asString()
                    local b = IOL_explore(iol_port, obj)
            end
    },
 
    SUB_WHAT = rfsm.state{
-           entry=function()
+           doo=function()
                    --
                    local answer = IOL_what(iol_port)
                    if  answer == "ack" then
@@ -208,7 +208,7 @@ return rfsm.state{
    },
 
    SUB_THIS = rfsm.state{
-           entry=function()
+           doo=function()
                    local obj = result:get(7):asString()
 
                    local b = IOL_this_is(iol_port, obj)
@@ -216,7 +216,7 @@ return rfsm.state{
    },
 
    SUB_LET = rfsm.state{
-           entry=function()
+           doo=function()
                    let_obj = result:get(17):asString()
                    let_arm = result:get(23):asString()
                    speak(ispeak_port,"Do you mean show me how to reach the " .. let_obj .. " with my " .. let_arm .." arm? ")

--- a/app/lua/iol_interact_fsm.lua
+++ b/app/lua/iol_interact_fsm.lua
@@ -1,22 +1,27 @@
 
-event_table = {
-   See       = "e_exit",
-   Calibrate = "e_calibrate",
-   Where     = "e_where",
-   I         = "e_i_will",
-   Take      = "e_take",
-   Grasp     = "e_grasp",
-   Return    = "e_home",
-   Touch     = "e_touch",
-   Push      = "e_push",
-   Forget    = "e_forget",
-   Explore   = "e_explore",
-   What      = "e_what",
-   This      = "e_this",
-   Let       = "e_let",
-   }
+return rfsm.state{
 
-interact_fsm = rfsm.state{
+  ----------------------------------
+  -- entry of root state          --
+  ----------------------------------
+  entry = function()
+    event_table = {
+       See       = "e_exit",
+       Calibrate = "e_calibrate",
+       Where     = "e_where",
+       I         = "e_i_will",
+       Take      = "e_take",
+       Grasp     = "e_grasp",
+       Return    = "e_home",
+       Touch     = "e_touch",
+       Push      = "e_push",
+       Forget    = "e_forget",
+       Explore   = "e_explore",
+       What      = "e_what",
+       This      = "e_this",
+       Let       = "e_let",
+       }
+  end,
 
    ----------------------------------
    -- state SUB_MENU               --

--- a/app/lua/iol_main.lua
+++ b/app/lua/iol_main.lua
@@ -2,43 +2,11 @@
 
 require("yarp")
 require("rfsm")
---require("iol_funcs")
 
 yarp.Network()
 
 -------
 shouldExit = false
-
--- initilization
-ispeak_port = yarp.BufferedPortBottle()
-speechRecog_port = yarp.Port()
-iol_port = yarp.Port()
-object_port = yarp.Port()
-
--- defining objects and actions vocabularies
-objects = {"Octopus", "Lego", "Toy", "Ladybug", "Turtle", "Car", "Bottle", "Box"}
-actions = {"{point at}", "{what is this}"}
-
--- defining speech grammar for Menu
-grammar = "Return to home position | Calibrate on table | Where is the #Object | Take the #Object | Grasp the #Object | See you soon  | I will teach you a new object | "
-       .."Touch the #Object | Push the #Object | Let me show you how to reach the #Object with your right arm | Let me show you how to reach the #Object with your left arm | "
-        .."Forget #Object | Forget all objects | Execute a plan | What is this | This is a #Object | Explore the #Object "
-
--- defining speech grammar for Reward
-grammar_reward = "Yes you are | No here it is | Skip it"
-
--- defining speech grammar for teaching a new object
-grammar_track = "There you go | Skip it"
-
--- defining speech grammar for what function (ack)
-grammar_whatAck = "Yes you are | No you are not | Skip it | Wrong this is a #Object"
-
--- defining speech grammar for what function (nack)
-grammar_whatNack = "This is a #Object | Skip it"
-
--- defining speech grammar teach reach
-grammar_teach = "Yes I do | No I do not | Finished"
-
 
 -- load state machine model and initalize it
 rf = yarp.ResourceFinder()

--- a/app/lua/iol_root_fsm.lua
+++ b/app/lua/iol_root_fsm.lua
@@ -27,7 +27,7 @@ return rfsm.state {
   -- state INIT_IOL               --
   ----------------------------------
   ST_INITIOL = rfsm.state{
-          entry=function()
+          doo=function()
                   ret = IOL_Initialize()
                   if ret == false then
                           rfsm.send_events(fsm, 'e_error')
@@ -41,7 +41,7 @@ return rfsm.state {
    -- state INITPORTS             --
    ----------------------------------
    ST_INITPORTS = rfsm.state{
-           entry=function()
+           doo=function()
                    ret = ispeak_port:open("/IOL/speak")
                    ret = ret and speechRecog_port:open("/IOL/speechRecog")
                    ret = ret and iol_port:open("/IOL/iolmanager")
@@ -58,7 +58,7 @@ return rfsm.state {
    -- state CONNECTPORTS           --
    ----------------------------------
    ST_CONNECTPORTS = rfsm.state{
-           entry=function()
+           doo=function()
                    ret = yarp.NetworkBase_connect(ispeak_port:getName(), "/iSpeak")
                    ret =  ret and yarp.NetworkBase_connect(speechRecog_port:getName(), "/speechRecognizer/rpc")
                    ret =  ret and yarp.NetworkBase_connect(iol_port:getName(), "/iolStateMachineHandler/human:rpc")
@@ -74,7 +74,7 @@ return rfsm.state {
    -- state RETREIVEMEMORY         --
    ----------------------------------
    ST_RETREIVEMEMORY = rfsm.state{
-           entry=function()
+           doo=function()
                    ret = true
                    ret = ret and (IH_Expand_vocab(object_port, objects) == "OK")
 
@@ -88,7 +88,7 @@ return rfsm.state {
    -- state INITVOCABS             --
    ----------------------------------
    ST_INITVOCABS = rfsm.state{
-           entry=function()
+           doo=function()
                    ret = true
                    for key, word in pairs(objects) do
                            ret = ret and (SM_RGM_Expand(speechRecog_port, "#Object", word) == "OK")
@@ -106,7 +106,7 @@ return rfsm.state {
    -- state HOME                   --
    ----------------------------------
    ST_HOME = rfsm.state{
-           entry=function()
+           doo=function()
                    print("everything is fine, going home!")
                    speak(ispeak_port, "Ready")
                    IOL_goHome(iol_port)
@@ -118,7 +118,7 @@ return rfsm.state {
    -- state FATAL                  --
    ----------------------------------
    ST_FATAL = rfsm.state{
-           entry=function()
+           doo=function()
                    print("Fatal!")
                    shouldExit = true;
            end
@@ -128,7 +128,7 @@ return rfsm.state {
    -- state FINI                   --
    ----------------------------------
    ST_FINI = rfsm.state{
-           entry=function()
+           doo=function()
                    print("Closing...")
                    yarp.NetworkBase_disconnect(ispeak_port:getName(), "/iSpeak")
                    yarp.NetworkBase_disconnect(speechRecog_port:getName(), "/speechRecognizer/rpc")

--- a/app/lua/iol_root_fsm.lua
+++ b/app/lua/iol_root_fsm.lua
@@ -1,22 +1,30 @@
-
+-- initialize yarp
 if yarp == nil then
-  require("yarp")
-  yarp.Network()
-end
+    require("yarp")
+    yarp.Network()
+end        
 
-if rf ~= nil then
-  dofile(rf:findFile("iol_interact_fsm.lua"))
-  dofile(rf:findFile("iol_funcs.lua"))
-else
-  dofile("iol_interact_fsm.lua")
-  dofile("iol_funcs.lua")
+-- find all required files 
+if rf ~= nil then 
+    iol_interact_fsm = rf:findFile("iol_interact_fsm.lua")
+    iol_funcs = rf:findFile("iol_funcs.lua")
+else 
+    iol_interact_fsm = "iol_interact_fsm.lua"
+    iol_funcs = "iol_funcs.lua"
 end
 
 
 return rfsm.state {
 
   ----------------------------------
-  -- state INIT_IOL                  --
+  -- entry of root state          --
+  ----------------------------------
+    entry=function()
+        dofile(iol_funcs)
+    end,
+
+  ----------------------------------
+  -- state INIT_IOL               --
   ----------------------------------
   ST_INITIOL = rfsm.state{
           entry=function()
@@ -139,7 +147,7 @@ return rfsm.state {
    --------------------------------------------
    -- state MENU  is defined in menu_fsm.lua --
    --------------------------------------------
-   ST_INTERACT = interact_fsm,
+   ST_INTERACT = dofile(iol_interact_fsm),
 
 
    ----------------------------------

--- a/app/lua/mobile/iol_funcs_mobile.lua
+++ b/app/lua/mobile/iol_funcs_mobile.lua
@@ -1,3 +1,36 @@
+function IOL_Mobile_Initialize()
+  -- initilization
+  ispeak_port = yarp.BufferedPortBottle()
+  speechRecog_port = yarp.BufferedPortBottle()
+  iol_port = yarp.Port()
+  object_port = yarp.Port()
+
+  -- defining objects and actions vocabularies
+  objects = {"Octopus", "Lego", "Toy", "Ladybug", "Turtle", "Car", "Bottle", "Box"}
+  actions = {"{point at}", "{what is this}"}
+
+  -- defining speech grammar for Menu
+  grammar = "Return to home position | Calibrate on table | Where is the #Object | Take the #Object | Grasp the #Object | See you soon  | I will teach you a new object | "
+         .."Touch the #Object | Push the #Object | Let me show you how to reach the #Object with your right arm | Let me show you how to reach the #Object with your left arm | "
+          .."Forget #Object | Forget all objects | Execute a plan | What is this | This is a #Object | Explore the #Object "
+
+  -- defining speech grammar for Reward
+  grammar_reward = "Yes you are | No here it is | Skip it"
+
+  -- defining speech grammar for teaching a new object
+  grammar_track = "There you go | Skip it"
+
+  -- defining speech grammar for what function (ack)
+  grammar_whatAck = "Yes you are | No you are not | Skip it | Wrong this is a #Object"
+
+  -- defining speech grammar for what function (nack)
+  grammar_whatNack = "This is a #Object | Skip it"
+
+  -- defining speech grammar teach reach
+  grammar_teach = "Yes I do | No I do not | Finished"
+
+  return (ispeak_port ~= nil) and (speechRecog_port ~= nil) and (iol_port ~= nil) and (object_port ~= nil)
+end
 
 function speak(port, str)
    local wb = port:prepare()
@@ -196,29 +229,29 @@ function Receive_Speech(port)
     local str = yarp.Bottle()
     local reply = yarp.Bottle()
     str = port:read(false)
-    
+
     if str == nill then
         --print ("null ")
     else
 
         print ("Initial is: ", str:toString())
         print ("size is: ", str:get(0):asList():size())
-        
+
         reply:clear()
         for i=0,str:get(0):asList():size()-1,1
-        do 
+        do
             inString = str:get(0):asList():get(i):asList():get(0):asString()
             print ("initial word is : ", inString)
             if (inString == "verb") then
                 verb = str:get(0):asList():get(i):asList():get(1):asString()
                 reply:addString(verb)
             end
-            
+
             if (inString == "object") then
                 verb = str:get(0):asList():get(i):asList():get(1):asString()
                 reply:addString(verb)
             end
-            
+
         end
 
         print ("reply is: ", reply:toString())

--- a/app/lua/mobile/iol_interact_fsm_mobile.lua
+++ b/app/lua/mobile/iol_interact_fsm_mobile.lua
@@ -1,23 +1,27 @@
 
-event_table = {
-   See       = "e_exit",
-   Calibrate = "e_calibrate",
-   Where     = "e_where",
-   I         = "e_i_will",
-   Take      = "e_take",
-   Grasp     = "e_grasp",
-   Return    = "e_home",
-   Touch     = "e_touch",
-   Push      = "e_push",
-   Forget    = "e_forget",
-   Explore   = "e_explore",
-   What      = "e_what",
-   This      = "e_this",
-   Let       = "e_let",
-   }
+return rfsm.state{
 
-
-interact_fsm = rfsm.state{
+    ----------------------------------
+    -- entry of root state          --
+    ----------------------------------
+    entry = function()
+      event_table = {
+         See       = "e_exit",
+         Calibrate = "e_calibrate",
+         Where     = "e_where",
+         I         = "e_i_will",
+         Take      = "e_take",
+         Grasp     = "e_grasp",
+         Return    = "e_home",
+         Touch     = "e_touch",
+         Push      = "e_push",
+         Forget    = "e_forget",
+         Explore   = "e_explore",
+         What      = "e_what",
+         This      = "e_this",
+         Let       = "e_let",
+         }
+    end,
 
     ----------------------------------
     -- state SUB_MENU               --

--- a/app/lua/mobile/iol_interact_fsm_mobile.lua
+++ b/app/lua/mobile/iol_interact_fsm_mobile.lua
@@ -56,7 +56,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_EXIT = rfsm.state{
-        entry=function()
+        doo=function()
             speak(ispeak_port, "Ok, bye bye")
             rfsm.send_events(fsm, 'e_menu_done')
         end
@@ -67,7 +67,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_CALIBRATE = rfsm.state{
-        entry=function()
+        doo=function()
             IOL_calibrate(iol_port)
             speak(ispeak_port,"OK, I know the table height")
     end
@@ -78,7 +78,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_WHERE = rfsm.state{
-        entry=function()
+        doo=function()
             local obj = result:get(1):asString()
             local b = IOL_where_is(iol_port, obj)
             local ret = b:get(0):asString()
@@ -118,7 +118,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_TEACH_OBJ = rfsm.state{
-        entry=function()
+        doo=function()
 
             IOL_track_start(iol_port)
 
@@ -170,7 +170,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_TAKE = rfsm.state{
-        entry=function()
+        doo=function()
             local obj = result:get(1):asString()
             print ("in take ", obj)
             local b = IOL_take(iol_port, obj)
@@ -182,7 +182,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_GRASP = rfsm.state{
-        entry=function()
+        doo=function()
             local obj = result:get(2):asString()
             local b = IOL_grasp(iol_port, obj)
         end
@@ -193,7 +193,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_RETURN = rfsm.state{
-        entry=function()
+        doo=function()
             print("going home!")
             IOL_goHome(iol_port)
         end
@@ -204,7 +204,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_TOUCH = rfsm.state{
-        entry=function()
+        doo=function()
             local obj = result:get(1):asString()
             print ("in touch ", obj)
             local b = IOL_touch(iol_port, obj)
@@ -216,7 +216,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_PUSH = rfsm.state{
-        entry=function()
+        doo=function()
             local obj = result:get(1):asString()
             print ("in push ", obj)
             local b = IOL_push(iol_port, obj)
@@ -228,7 +228,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_FORGET = rfsm.state{
-        entry=function()
+        doo=function()
             local obj
             obj= result:get(1):asString()
              print ("in forget ", obj)
@@ -247,7 +247,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_EXPLORE = rfsm.state{
-        entry=function()
+        doo=function()
             local obj = result:get(1):asString()
             print ("in explore ", obj)
             local b = IOL_explore(iol_port, obj)
@@ -259,7 +259,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_WHAT = rfsm.state{
-    entry=function()
+    doo=function()
         local answer = IOL_what(iol_port)
 
             if  answer == "ack" then
@@ -317,7 +317,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_THIS = rfsm.state{
-            entry=function()
+            doo=function()
                     local obj = result:get(7):asString()
 
                     local b = IOL_this_is(iol_port, obj)
@@ -329,7 +329,7 @@ return rfsm.state{
     ----------------------------------
 
     SUB_LET = rfsm.state{
-    entry=function()
+    doo=function()
         let_obj = result:get(8):asString()
         let_arm = result:get(11):asString()
         speak(ispeak_port,"Do you mean show me how to reach the " .. let_obj .. " with my " .. let_arm .." arm? ")

--- a/app/lua/mobile/iol_main_mobile.lua
+++ b/app/lua/mobile/iol_main_mobile.lua
@@ -9,37 +9,6 @@ yarp.Network()
 -------
 shouldExit = false
 
--- initilization
-ispeak_port = yarp.BufferedPortBottle()
-speechRecog_port = yarp.BufferedPortBottle()
-iol_port = yarp.Port()
-object_port = yarp.Port()
-
--- defining objects and actions vocabularies
-objects = {"Octopus", "Lego", "Toy", "Ladybug", "Turtle", "Car", "Bottle", "Box"}
-actions = {"{point at}", "{what is this}"}
-
--- defining speech grammar for Menu
-grammar = "Return to home position | Calibrate on table | Where is the #Object | Take the #Object | Grasp the #Object | See you soon  | I will teach you a new object | "
-       .."Touch the #Object | Push the #Object | Let me show you how to reach the #Object with your right arm | Let me show you how to reach the #Object with your left arm | "
-        .."Forget #Object | Forget all objects | Execute a plan | What is this | This is a #Object | Explore the #Object "
-
--- defining speech grammar for Reward
-grammar_reward = "Yes you are | No here it is | Skip it"
-
--- defining speech grammar for teaching a new object
-grammar_track = "There you go | Skip it"
-
--- defining speech grammar for what function (ack)
-grammar_whatAck = "Yes you are | No you are not | Skip it | Wrong this is a #Object"
-
--- defining speech grammar for what function (nack)
-grammar_whatNack = "This is a #Object | Skip it"
-
--- defining speech grammar teach reach
-grammar_teach = "Yes I do | No I do not | Finished"
-
-
 -- load state machine model and initalize it
 rf = yarp.ResourceFinder()
 rf:setDefaultContext("iol/lua")

--- a/app/lua/mobile/iol_root_fsm_mobile.lua
+++ b/app/lua/mobile/iol_root_fsm_mobile.lua
@@ -71,38 +71,6 @@ return rfsm.state {
    },
 
    ----------------------------------
-   -- state RETREIVEMEMORY         --
-   ----------------------------------
-   ST_RETREIVEMEMORY = rfsm.state{
-           entry=function()
-                   ret = true
-                   ret = ret and (IH_Expand_vocab(object_port, objects) == "OK")
-
-                   if ret == false then
-                           rfsm.send_events(fsm, 'e_error')
-                   end
-           end
-           },
-
-   ----------------------------------
-   -- state INITVOCABS             --
-   ----------------------------------
-   ST_INITVOCABS = rfsm.state{
-           entry=function()
-                   ret = true
-                   for key, word in pairs(objects) do
-                           ret = ret and (SM_RGM_Expand(speechRecog_port, "#Object", word) == "OK")
-                   end
-
-                   SM_Expand_asyncrecog(speechRecog_port, "icub-stop-now")
-
-                   if ret == false then
-                          rfsm.send_events(fsm, 'e_error')
-                   end
-           end
-   },
-
-   ----------------------------------
    -- state HOME                   --
    ----------------------------------
    ST_HOME = rfsm.state{

--- a/app/lua/mobile/iol_root_fsm_mobile.lua
+++ b/app/lua/mobile/iol_root_fsm_mobile.lua
@@ -27,7 +27,7 @@ return rfsm.state {
     -- state INIT_IOL               --
     ----------------------------------
     ST_INITIOL = rfsm.state{
-            entry=function()
+            doo=function()
                     ret = IOL_Mobile_Initialize()
                     if ret == false then
                             rfsm.send_events(fsm, 'e_error')
@@ -41,7 +41,7 @@ return rfsm.state {
    -- state INITPORTS                  --
    ----------------------------------
    ST_INITPORTS = rfsm.state{
-           entry=function()
+           doo=function()
                    ret = ispeak_port:open("/IOL/speak")
                    ret = ret and speechRecog_port:open("/IOL/speechRecog")
                    ret = ret and iol_port:open("/IOL/iolmanager")
@@ -58,7 +58,7 @@ return rfsm.state {
    -- state CONNECTPORTS           --
    ----------------------------------
    ST_CONNECTPORTS = rfsm.state{
-           entry=function()
+           doo=function()
                    ret = yarp.NetworkBase_connect(ispeak_port:getName(), "/iSpeak")
                    ret =  ret and yarp.NetworkBase_connect("/interpretSTART/start:o" , "/IOL/speechRecog")
                    ret =  ret and yarp.NetworkBase_connect(iol_port:getName(), "/iolStateMachineHandler/human:rpc")
@@ -74,7 +74,7 @@ return rfsm.state {
    -- state HOME                   --
    ----------------------------------
    ST_HOME = rfsm.state{
-           entry=function()
+           doo=function()
                    print("everything is fine, going home!")
                    speak(ispeak_port, "Ready")
                    IOL_goHome(iol_port)
@@ -86,7 +86,7 @@ return rfsm.state {
    -- state FATAL                  --
    ----------------------------------
    ST_FATAL = rfsm.state{
-           entry=function()
+           doo=function()
                    print("Fatal!")
                    shouldExit = true;
            end
@@ -96,7 +96,7 @@ return rfsm.state {
    -- state FINI                   --
    ----------------------------------
    ST_FINI = rfsm.state{
-           entry=function()
+           doo=function()
                    print("Closing...")
                    yarp.NetworkBase_disconnect(ispeak_port:getName(), "/iSpeak")
                    yarp.NetworkBase_disconnect("/yarpdroid/STT:o" , speechRecog_port:getName())

--- a/app/scripts/iol.xml.template
+++ b/app/scripts/iol.xml.template
@@ -124,7 +124,7 @@
         <module>
             <name>rfsmGui</name>
             <node>console</node>
-            <parameters>-f <path to context>/iol/lua/iol_root_fsm.lua --run</parameters>
+            <parameters>--rfsm iol_root_fsm.lua --context iol/lua --run</parameters>
             <dependencies>
                 <port timeout="10">/iSpeak</port>
                 <port timeout="10">/speechRecognizer/rpc</port>

--- a/app/scripts/iol.xml.template
+++ b/app/scripts/iol.xml.template
@@ -107,10 +107,24 @@
                 <parameters>--name /iolViewer/manager/histogram --x 680 --y 220 --w 600 --h 600 --p 50 --compact</parameters>
                 <node>console</node>
         </module>
+
+        <!--
         <module>
             <name>iol_main.lua</name>
             <deployer>lua</deployer>
             <node>console</node>
+            <dependencies>
+                <port timeout="10">/iSpeak</port>
+                <port timeout="10">/speechRecognizer/rpc</port>
+                <port timeout="10">/iolStateMachineHandler/human:rpc</port>
+                <port timeout="10">/iolHelper/rpc</port>
+            </dependencies>
+        </module> -->
+
+        <module>
+            <name>rfsmGui</name>
+            <node>console</node>
+            <parameters>-f <path to context>/iol/lua/iol_root_fsm.lua --run</parameters>
             <dependencies>
                 <port timeout="10">/iSpeak</port>
                 <port timeout="10">/speechRecognizer/rpc</port>


### PR DESCRIPTION
In this pull request:
 - the initialization of the iol (yarp.network, port opening, grammar, ..) has been moved to `IOL_Initialize()`  function 
- the `iol_main.lua` has been simplified to just lunch the rfsm 
- a new state for initializing iol has been added 

