### PR TITLE
Fix issue appearing after pull request #28 (reverted in #29).

### DIFF
--- a/src/iolStateMachineHandler/include/classifierHandling.h
+++ b/src/iolStateMachineHandler/include/classifierHandling.h
@@ -76,7 +76,7 @@ public:
     void   clear();
     void   erase(iterator it);
     int    processScores(Classifier *pClassifier, const Bottle &scores);
-    string findName(const Bottle &scores, const string &tag);
+    string findName(const Bottle &scores, const string &tag, double *score=nullptr);
 };
 
 #endif

--- a/src/iolStateMachineHandler/src/classifierHandling.cpp
+++ b/src/iolStateMachineHandler/src/classifierHandling.cpp
@@ -313,9 +313,11 @@ int ClassifiersDataBase::processScores(Classifier *pClassifier,
 
 /**********************************************************/
 string ClassifiersDataBase::findName(const Bottle &scores,
-                                     const string &tag)
+                                     const string &tag,
+                                     double *score)
 {
     string retName=OBJECT_UNKNOWN;
+    if(score) *score = 0;
     Bottle *blobScores=scores.find(tag).asList();
     if (blobScores==NULL)
         return retName;
@@ -356,6 +358,7 @@ string ClassifiersDataBase::findName(const Bottle &scores,
         }
     }
 
+    if(score) *score = maxScore;
     return retName;
 }
 

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -2013,6 +2013,9 @@ void Manager::updateMemory()
         for (map<string,Tracker>::iterator it=trackersPool.begin(); it!=trackersPool.end(); it++)
             it->second.prepare();
         
+        // Classification scores for each object
+        std::map<string, double> scoresMap;
+
         for (int j=0; j<blobs.size(); j++)
         {
             Bottle *item=blobs.get(j).asList();
@@ -2022,13 +2025,16 @@ void Manager::updateMemory()
             ostringstream tag;
             tag<<"blob_"<<j;
 
-            // find the blob name (or unknown)
+            // find the blob name and classification score (or unknown)
+            double score = 0;
             mutexResources.lock();
-            string object=db.findName(scores,tag.str());
+            string object=db.findName(scores,tag.str(),&score);
             mutexResources.unlock();
 
             if (object!=OBJECT_UNKNOWN)
             {
+                scoresMap[object] = score;
+
                 // compute the bounding box
                 cv::Point tl,br;
                 tl.x=(int)item->get(0).asDouble();
@@ -2084,6 +2090,12 @@ void Manager::updateMemory()
                     list_3d.addString("position_3d");
                     list_3d.addList().read(x);
 
+                    // prepare class_score property
+                    Bottle class_score;
+                    Bottle &list_score=class_score.addList();
+                    list_score.addString("class_score");
+                    list_score.addDouble(scoresMap[object]);
+
                     mutexResourcesMemory.lock();
                     map<string,int>::iterator id=memoryIds.find(object);
                     map<string,int>::iterator memoryIdsEnd=memoryIds.end();
@@ -2102,6 +2114,7 @@ void Manager::updateMemory()
                         list_name.addString(object);
                         content.append(position_2d);
                         content.append(position_3d);
+                        content.append(class_score);
                         rpcMemory.write(cmdMemory,replyMemory);
 
                         if (replyMemory.size()>1)
@@ -2136,6 +2149,7 @@ void Manager::updateMemory()
                         content.append(bid);
                         content.append(position_2d);
                         content.append(position_3d);
+                        content.append(class_score);
                         rpcMemory.write(cmdMemory,replyMemory);
 
                         avalObjIds.insert(id->second);

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -2090,11 +2090,15 @@ void Manager::updateMemory()
                     list_3d.addString("position_3d");
                     list_3d.addList().read(x);
 
-                    // prepare class_score property
+                    // prepare class_score property if the object's been freshly recognized
                     Bottle class_score;
-                    Bottle &list_score=class_score.addList();
-                    list_score.addString("class_score");
-                    list_score.addDouble(scoresMap[object]);
+                    auto it=scoresMap.find(object);
+                    if (it!=scoresMap.end())
+                    {
+                        Bottle &list_score=class_score.addList();
+                        list_score.addString("class_score");
+                        list_score.addDouble(it->second);
+                    }
 
                     mutexResourcesMemory.lock();
                     map<string,int>::iterator id=memoryIds.find(object);
@@ -2114,7 +2118,9 @@ void Manager::updateMemory()
                         list_name.addString(object);
                         content.append(position_2d);
                         content.append(position_3d);
-                        content.append(class_score);
+                        if (class_score.size()>0)
+                            content.append(class_score);
+
                         rpcMemory.write(cmdMemory,replyMemory);
 
                         if (replyMemory.size()>1)
@@ -2149,7 +2155,9 @@ void Manager::updateMemory()
                         content.append(bid);
                         content.append(position_2d);
                         content.append(position_3d);
-                        content.append(class_score);
+                        if (class_score.size()>0)
+                            content.append(class_score);
+
                         rpcMemory.write(cmdMemory,replyMemory);
 
                         avalObjIds.insert(id->second);
@@ -2186,6 +2194,7 @@ void Manager::updateMemory()
                 Bottle &list_items=list_propSet.addList();
                 list_items.addString("position_2d_"+camera);
                 list_items.addString("position_3d");
+                list_items.addString("class_score");
                 rpcMemory.write(cmdMemory,replyMemory);
             }
         }


### PR DESCRIPTION
Use std::map `operator[]` instead of `.at` to avoid throwing an exception when key is not in the list (it automatically adds the key in the map with a value 0.0 instead).
Missing key should ideally not appear but it actually can due to missing synchronization between tracking and classification processes.