### PR TITLE
Fix several issues in IOLStateMachineHandler and himrepClassifier

### DIFF
--- a/src/himrepClassifier/classifier.cpp
+++ b/src/himrepClassifier/classifier.cpp
@@ -259,7 +259,9 @@ bool Classifier::train(Bottle *locations, Bottle &reply)
     // crop image
     ImageOf<PixelRgb> croppedImg;
     croppedImg.resize(blobW,blobH);
-    toCvMat(*image)(cv::Rect(x_min,y_min,blobW,blobH)).copyTo(toCvMat(croppedImg));
+    for(int j=0 ; j<blobH ; j++)
+        for(int i=0 ; i<blobW ; i++)
+            croppedImg(i,j) = (*image)(x_min+i,y_min+j);
 
     // send image to SC
     imgOutput.write(croppedImg);
@@ -383,7 +385,9 @@ void Classifier::classify(Bottle *blobs, Bottle &reply)
         // crop image
         ImageOf<PixelRgb> croppedImg;
         croppedImg.resize(x_max-x_min,y_max-y_min);
-        toCvMat(*image)(cv::Rect(x_min,y_min,x_max-x_min,y_max-y_min)).copyTo(toCvMat(croppedImg));
+        for(int j=0 ; j<y_max-y_min ; j++)
+            for(int i=0 ; i<x_max-x_min ; i++)
+                croppedImg(i,j) = (*image)(x_min+i,y_min+j);
 
         // send image to SC
         imgOutput.write(croppedImg);
@@ -397,7 +401,9 @@ void Classifier::classify(Bottle *blobs, Bottle &reply)
 
         x_max=std::min(x_min+imgSift->width(),image->width()-1);
         y_max=std::min(y_min+imgSift->height(),image->height()-1);
-        toCvMat(*imgSift)(cv::Rect(0,0,x_max-x_min,y_max-y_min)).copyTo(toCvMat(*image)(cv::Rect(x_min,y_min,x_max-x_min,y_max-y_min)));
+        for(int j=0 ; j<y_max-y_min ; j++)
+            for(int i=0 ; i<x_max-x_min ; i++)
+                (*image)(i,j) = (*imgSift)(i,j);
 
         // send feature to classifier
         featureOutput.write(fea);

--- a/src/himrepClassifier/classifier.cpp
+++ b/src/himrepClassifier/classifier.cpp
@@ -257,11 +257,10 @@ bool Classifier::train(Bottle *locations, Bottle &reply)
     int blobH=y_max-y_min;
 
     // crop image
-    ImageOf<PixelRgb> croppedImg;
-    croppedImg.resize(blobW,blobH);
-    for(int j=0 ; j<blobH ; j++)
-        for(int i=0 ; i<blobW ; i++)
-            croppedImg(i,j) = (*image)(x_min+i,y_min+j);
+    ImageOf<PixelRgb> tmp_img = *image;
+    ::cv::Mat mat_tmp_img = toCvMat(tmp_img);
+    ::cv::Mat mat_croppedImg = mat_tmp_img(cv::Rect(x_min,y_min,blobW,blobH)).clone();
+    ImageOf<PixelRgb> croppedImg = fromCvMat<PixelRgb>(mat_croppedImg);
 
     // send image to SC
     imgOutput.write(croppedImg);
@@ -383,11 +382,10 @@ void Classifier::classify(Bottle *blobs, Bottle &reply)
            y_max+=5;
 
         // crop image
-        ImageOf<PixelRgb> croppedImg;
-        croppedImg.resize(x_max-x_min,y_max-y_min);
-        for(int j=0 ; j<y_max-y_min ; j++)
-            for(int i=0 ; i<x_max-x_min ; i++)
-                croppedImg(i,j) = (*image)(x_min+i,y_min+j);
+        ImageOf<PixelRgb> tmp_img = *image;
+        ::cv::Mat mat_tmp_img = toCvMat(tmp_img);
+        ::cv::Mat mat_croppedImg = mat_tmp_img(cv::Rect(x_min,y_min,x_max-x_min,y_max-y_min)).clone();
+        ImageOf<PixelRgb>  croppedImg = fromCvMat<PixelRgb>(mat_croppedImg);
 
         // send image to SC
         imgOutput.write(croppedImg);
@@ -401,9 +399,8 @@ void Classifier::classify(Bottle *blobs, Bottle &reply)
 
         x_max=std::min(x_min+imgSift->width(),image->width()-1);
         y_max=std::min(y_min+imgSift->height(),image->height()-1);
-        for(int j=0 ; j<y_max-y_min ; j++)
-            for(int i=0 ; i<x_max-x_min ; i++)
-                (*image)(i,j) = (*imgSift)(i,j);
+        toCvMat(*imgSift)(cv::Rect(0,0,x_max-x_min,y_max-y_min)).copyTo(mat_tmp_img(cv::Rect(x_min,y_min,x_max-x_min,y_max-y_min)));
+        *image = fromCvMat<PixelRgb>(mat_tmp_img);
 
         // send feature to classifier
         featureOutput.write(fea);

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -480,20 +480,20 @@ void Manager::drawScoresHistogram(const Bottle &blobs,
             {
                 if (imgTmp2_width>imgConf.width()/4)
                 {
-                    double r=imgTmp2_height/imgTmp2_width;
+                    double r=(double)imgTmp2_height/(double)imgTmp2_width;
                     imgTmp2_width=imgConf.width()/4;
                     imgTmp2_height=(size_t)(r*imgTmp2_width);
                 }
             }
             else if (imgTmp2_height>imgConf.height()/4)
             {
-                double r=imgTmp2_width/imgTmp2_height;
+                double r=(double)imgTmp2_width/(double)imgTmp2_height;
                 imgTmp2_height=imgConf.height()/4;
                 imgTmp2_width=(size_t)(r*imgTmp2_height);
             }
 
             ImageOf<PixelBgr> imgTmp2;
-            imgTmp2.resize(imgTmp2_width,imgTmp2_height);
+            imgTmp2.resize(max((size_t)1,imgTmp2_width),max((size_t)1,imgTmp2_height));
             cv::Mat imgTmp2Mat=toCvMat(imgTmp2);
             cv::resize(imgTmp1Mat,imgTmp2Mat,imgTmp2Mat.size());
 
@@ -776,7 +776,7 @@ bool Manager::calibKinStart(const string &object, const string &hand,
 
         Vector y;
         if (interruptableAction("touch",&param,object,x,y))
-        {            
+        {
             Bottle cmdMotor,replyMotor;
             cmdMotor.addVocab(Vocab::encode("calib"));
             cmdMotor.addVocab(Vocab::encode("kinematics"));
@@ -1053,7 +1053,7 @@ void Manager::interruptMotor()
 
 /**********************************************************/
 void Manager::reinstateMotor(const bool saySorry)
-{        
+{
     Bottle cmdMotorStop,replyMotorStop;
     cmdMotorStop.addVocab(Vocab::encode("reinstate"));
     rpcMotorStop.write(cmdMotorStop,replyMotorStop);
@@ -1868,7 +1868,7 @@ void Manager::doLocalization()
     Bottle scores=classify(blobs,true);
     // update location of histogram display
     if (Bottle *loc=histObjLocPort.read(false))
-    {        
+    {
         if (loc->size()>=2)
         {
             Vector x;
@@ -2724,7 +2724,7 @@ bool Manager::updateModule()
             Bottle blobs;
             string hand=cmdHuman.get(2).toString();
             string activeObject=cmdHuman.get(3).toString();
-            
+
             mutexMemoryUpdate.lock();
             int recogBlob=recognize(activeObject,blobs);
             Vector x=updateObjCartPosInMemory(activeObject,blobs,recogBlob);
@@ -2775,12 +2775,12 @@ bool Manager::updateModule()
         return true;    // avoid resuming the attention
     }
     else if ((rxCmd==Vocab::encode("name")) && (valHuman.size()>0))
-    {        
+    {
         string activeObject=valHuman.get(0).asString();
         execName(activeObject);
     }
     else if ((rxCmd==Vocab::encode("forget")) && (valHuman.size()>0))
-    {        
+    {
         string activeObject=valHuman.get(0).asString();
 
         mutexMemoryUpdate.lock();
@@ -2788,7 +2788,7 @@ bool Manager::updateModule()
         mutexMemoryUpdate.unlock();
     }
     else if ((rxCmd==Vocab::encode("where")) && (valHuman.size()>0))
-    {        
+    {
         Bottle blobs;
         Classifier *pClassifier;
         string activeObject=valHuman.get(0).asString();
@@ -2848,7 +2848,7 @@ bool Manager::updateModule()
     else if ((rxCmd==Vocab::encode("take"))  || (rxCmd==Vocab::encode("grasp")) ||
              (rxCmd==Vocab::encode("touch")) || (rxCmd==Vocab::encode("push"))  ||
              (rxCmd==Vocab::encode("hold"))  || (rxCmd==Vocab::encode("drop")))
-    {        
+    {
         Bottle blobs;
         string activeObject="";
         int recogBlob=RET_INVALID;

--- a/src/iolStateMachineHandler/src/module.cpp
+++ b/src/iolStateMachineHandler/src/module.cpp
@@ -493,7 +493,7 @@ void Manager::drawScoresHistogram(const Bottle &blobs,
             }
 
             ImageOf<PixelBgr> imgTmp2;
-            imgTmp2.resize(max((size_t)1,imgTmp2_width),max((size_t)1,imgTmp2_height));
+            imgTmp2.resize(std::max((size_t)1,imgTmp2_width),std::max((size_t)1,imgTmp2_height));
             cv::Mat imgTmp2Mat=toCvMat(imgTmp2);
             cv::resize(imgTmp1Mat,imgTmp2Mat,imgTmp2Mat.size());
 


### PR DESCRIPTION
This PR fixes two things so that the IOL pipeline works again:

- fix the patch resizing on the histogram image: the rescale factor was always zero due to `int` division leading to zero-sized image (and crash of the application).
The PR fixes the issue and adds a safe-guard to ensure that the image dimension is at least 1.

- fix color conversion issues (red and blue channel inverted) so that correct images are sent on the ports.
Note: this requires that the color fix in `caffeCoder` (https://github.com/robotology/himrep/pull/35) is also applied.

